### PR TITLE
fix(blur): 🐛 added blur has from helper function

### DIFF
--- a/src/pages/api/bookmark/add-remaining-bookmark-data.ts
+++ b/src/pages/api/bookmark/add-remaining-bookmark-data.ts
@@ -5,7 +5,6 @@ import { type NextApiResponse } from "next";
 import { type PostgrestError } from "@supabase/supabase-js";
 import axios from "axios";
 import { decode } from "base64-arraybuffer";
-import { blurhashFromURL } from "blurhash-from-url";
 import { type VerifyErrors } from "jsonwebtoken";
 import jwtDecode from "jwt-decode";
 import { isEmpty, isNil, isNull } from "lodash";
@@ -23,6 +22,7 @@ import {
 	STORAGE_SCRAPPED_IMAGES_PATH,
 	URL_IMAGE_CHECK_PATTERN,
 } from "../../../utils/constants";
+import { blurhashFromURL } from "../../../utils/getBlurHash";
 import { getBaseUrl } from "../../../utils/helpers";
 import {
 	apiSupabaseClient,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to bookmark-tags! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`][1]
- [ ] Steps in [CONTRIBUTING.md][2] were taken

## Overview

We are using blur has from the lib in add remaining bookmarks data api . Because of this sharp lib issue in vercel is coming

<!-- Description of what is changed and how the code change does that. -->

[1]:
	https://github.com/timelessco/bookmark-tags/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22
[2]:
	https://github.com/timelessco/bookmark-tags/blob/main/.github/CONTRIBUTING.md
