### PR TITLE
refactor(prod env): ♻️ removed PROD and added DEV to supabase envs

### DIFF
--- a/env.local.txt
+++ b/env.local.txt
@@ -21,17 +21,16 @@ SCREENSHOT_TOKEN as per https://github.com/timelessco/screenshot-api (OPTIONAL, 
 // once you create a project you need to add the following keys that is given by supabase to the project
 // supabase for production
 // when in production the app will point out to these keys 
-PROD_SUPABASE_JWT_SECRET_KEY
-PROD_SUPABASE_SERVICE_KEY
-NEXT_PUBLIC_PROD_SUPABASE_ANON_KEY
-NEXT_PUBLIC_PROD_SUPABASE_URL
-
-// The above 4 keys are required and the below are OPTIONAL
-// if you want the app to point out to different supabase projects based on dev and prod then you can use these below env variables
-// all the env variables in the below OPTIONAL will only point out in dev mode
-
-OPTIONAL keys: 
 SUPABASE_JWT_SECRET_KEY
 SUPABASE_SERVICE_KEY
 NEXT_PUBLIC_SUPABASE_ANON_KEY
 NEXT_PUBLIC_SUPABASE_URL
+
+// The above 4 keys are required and the below are OPTIONAL
+// if you want the app to point out to different supabase projects based on dev and prod then you can use these below env variables
+// all the env variables in the below OPTIONAL will only point out in dev mode
+OPTIONAL keys: 
+DEV_SUPABASE_JWT_SECRET_KEY
+DEV_SUPABASE_SERVICE_KEY
+NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY
+NEXT_PUBLIC_DEV_SUPABASE_URL

--- a/env/schema.js
+++ b/env/schema.js
@@ -8,15 +8,15 @@ import { z } from "zod";
  */
 export const serverSchema = z.object({
 	NODE_ENV: z.enum(["development", "test", "production"]),
-	SUPABASE_SERVICE_KEY: z.string()?.optional(),
-	SUPABASE_JWT_SECRET_KEY: z.string().optional(),
+	SUPABASE_SERVICE_KEY: z.string(),
+	SUPABASE_JWT_SECRET_KEY: z.string(),
 	SENDGRID_KEY: z.string().optional(),
 	SENTRY_DSN: z.string().optional(),
 	SCREENSHOT_TOKEN: z.string().optional(),
 	IMAGE_CAPTION_URL: z.string().optional(),
 	IMAGE_CAPTION_TOKEN: z.string().optional(),
-	PROD_SUPABASE_JWT_SECRET_KEY: z.string(),
-	PROD_SUPABASE_SERVICE_KEY: z.string(),
+	DEV_SUPABASE_JWT_SECRET_KEY: z.string().optional(),
+	DEV_SUPABASE_SERVICE_KEY: z.string().optional(),
 });
 
 /**
@@ -34,8 +34,8 @@ export const serverEnvironment = {
 	SUPABASE_JWT_SECRET_KEY: process.env.SUPABASE_JWT_SECRET_KEY,
 	IMAGE_CAPTION_URL: process.env.IMAGE_CAPTION_URL,
 	IMAGE_CAPTION_TOKEN: process.env.IMAGE_CAPTION_TOKEN,
-	PROD_SUPABASE_JWT_SECRET_KEY: process.env.PROD_SUPABASE_JWT_SECRET_KEY,
-	PROD_SUPABASE_SERVICE_KEY: process.env.PROD_SUPABASE_SERVICE_KEY,
+	DEV_SUPABASE_JWT_SECRET_KEY: process.env.DEV_SUPABASE_JWT_SECRET_KEY,
+	DEV_SUPABASE_SERVICE_KEY: process.env.DEV_SUPABASE_SERVICE_KEY,
 };
 
 /**
@@ -46,10 +46,10 @@ export const serverEnvironment = {
 export const clientSchema = z.object({
 	// Needed for sitemap generation
 	NEXT_PUBLIC_SITE_URL: z.string().url()?.optional(),
-	NEXT_PUBLIC_SUPABASE_URL: z.string().url().optional(),
-	NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
-	NEXT_PUBLIC_PROD_SUPABASE_ANON_KEY: z.string(),
-	NEXT_PUBLIC_PROD_SUPABASE_URL: z.string(),
+	NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+	NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+	NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY: z.string().optional(),
+	NEXT_PUBLIC_DEV_SUPABASE_URL: z.string().optional(),
 });
 
 /**
@@ -64,7 +64,7 @@ export const clientEnvironment = {
 	NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
 	NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
 	NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-	NEXT_PUBLIC_PROD_SUPABASE_ANON_KEY:
-		process.env.NEXT_PUBLIC_PROD_SUPABASE_ANON_KEY,
-	NEXT_PUBLIC_PROD_SUPABASE_URL: process.env.NEXT_PUBLIC_PROD_SUPABASE_URL,
+	NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY:
+		process.env.NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY,
+	NEXT_PUBLIC_DEV_SUPABASE_URL: process.env.NEXT_PUBLIC_DEV_SUPABASE_URL,
 };

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,8 +1,18 @@
 import { isProductionEnvironment } from "./supabaseServerClient";
 
-export const supabaseUrl = isProductionEnvironment
-	? process.env.NEXT_PUBLIC_PROD_SUPABASE_URL
+// in case the user did not add the supabase dev keys in env file then even in dev mode the app will point out to the prod keys mentioned in the env file
+// the below ternary conditions handel this logic
+const developmentSupabaseUrl = process.env.NEXT_PUBLIC_DEV_SUPABASE_URL
+	? process.env.NEXT_PUBLIC_DEV_SUPABASE_URL
 	: process.env.NEXT_PUBLIC_SUPABASE_URL;
-export const supabaseAnonKey = isProductionEnvironment
-	? process.env.NEXT_PUBLIC_PROD_SUPABASE_ANON_KEY
+
+const developmentSupabaseAnonKey = process.env.NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY
+	? process.env.NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY
+	: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabaseUrl = !isProductionEnvironment
+	? developmentSupabaseUrl
+	: process.env.NEXT_PUBLIC_SUPABASE_URL;
+export const supabaseAnonKey = !isProductionEnvironment
+	? developmentSupabaseAnonKey
 	: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;

--- a/src/utils/supabaseServerClient.ts
+++ b/src/utils/supabaseServerClient.ts
@@ -5,25 +5,25 @@ export const isProductionEnvironment = process.env.NODE_ENV === "production";
 
 // in case the user did not add the supabase dev keys in env file then even in dev mode the app will point out to the prod keys mentioned in the env file
 // the below ternary conditions handel this logic
-const developmentSupbaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-	? process.env.NEXT_PUBLIC_SUPABASE_URL
-	: process.env.NEXT_PUBLIC_PROD_SUPABASE_URL;
+const developmentSupbaseUrl = process.env.NEXT_PUBLIC_DEV_SUPABASE_URL
+	? process.env.NEXT_PUBLIC_DEV_SUPABASE_URL
+	: process.env.NEXT_PUBLIC_SUPABASE_URL;
 
-const developmentSupabaseServiceKey = process.env.SUPABASE_SERVICE_KEY
-	? process.env.SUPABASE_SERVICE_KEY
-	: process.env.PROD_SUPABASE_SERVICE_KEY;
+const developmentSupabaseServiceKey = process.env.DEV_SUPABASE_SERVICE_KEY
+	? process.env.DEV_SUPABASE_SERVICE_KEY
+	: process.env.SUPABASE_SERVICE_KEY;
 
-const developmentSupabaseSecretKey = process.env.SUPABASE_JWT_SECRET_KEY
-	? process.env.SUPABASE_JWT_SECRET_KEY
-	: process.env.PROD_SUPABASE_JWT_SECRET_KEY;
+const developmentSupabaseSecretKey = process.env.DEV_SUPABASE_JWT_SECRET_KEY
+	? process.env.DEV_SUPABASE_JWT_SECRET_KEY
+	: process.env.SUPABASE_JWT_SECRET_KEY;
 
 export const apiSupabaseClient = () => {
 	const supabase = createClient(
 		isProductionEnvironment
-			? process.env.NEXT_PUBLIC_PROD_SUPABASE_URL
+			? process.env.NEXT_PUBLIC_SUPABASE_URL
 			: developmentSupbaseUrl,
 		isProductionEnvironment
-			? process.env.PROD_SUPABASE_SERVICE_KEY
+			? process.env.SUPABASE_SERVICE_KEY
 			: developmentSupabaseServiceKey,
 	);
 
@@ -36,7 +36,7 @@ export const verifyAuthToken = (accessToken: string) =>
 	verify(
 		accessToken,
 		isProductionEnvironment
-			? process.env.PROD_SUPABASE_JWT_SECRET_KEY
+			? process.env.SUPABASE_JWT_SECRET_KEY
 			: developmentSupabaseSecretKey,
 		(error, decoded) => ({ error, decoded }),
 	) as unknown as {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to bookmark-tags! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`][1]
- [ ] Steps in [CONTRIBUTING.md][2] were taken

## Overview

The default supabase envs are now pointing to prod supabase project and the dev env variables how can DEV in their names. This is to only have 4 env variables when the user self deploys the app in vercel

<!-- Description of what is changed and how the code change does that. -->

[1]: https://github.com/timelessco/bookmark-tags/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22
[2]: https://github.com/timelessco/bookmark-tags/blob/main/.github/CONTRIBUTING.md
