### PR TITLE
fix(option): remove unnecessary pointer-events class from anchor element

### DIFF
--- a/src/pageComponents/dashboard/cardSection/option.tsx
+++ b/src/pageComponents/dashboard/cardSection/option.tsx
@@ -107,7 +107,7 @@ const Option = ({
 			{/* we are disabling as this a tag is only to tell card is a link , but its eventually not functional */}
 			{/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
 			<a
-				className="pointer-events-none  absolute left-0 top-0 z-10 h-full w-full rounded-lg"
+				className="absolute left-0 top-0  h-full w-full rounded-lg"
 				draggable={false}
 				href={url}
 				onClick={(event) => {


### PR DESCRIPTION
hot fix lightbox is not clickable