### PR TITLE
fix(x-favicon): 🐛 baseurl is not needed for x.com

### DIFF
--- a/src/pages/api/bookmark/add-remaining-bookmark-data.ts
+++ b/src/pages/api/bookmark/add-remaining-bookmark-data.ts
@@ -175,17 +175,19 @@ export default async function handler(
 	}
 
 	const favIconLogic = async () => {
-		const url2 = new URL(url);
+		const { hostname } = new URL(url);
 
 		if (favIcon) {
 			if (favIcon?.includes("https://")) {
 				return favIcon;
 			} else {
-				return `https://${getBaseUrl(url)}${favIcon}`;
+				return hostname === "x.com"
+					? favIcon
+					: `https://${getBaseUrl(url)}${favIcon}`;
 			}
 		} else {
 			const response2 = await fetch(
-				`https://www.google.com/s2/favicons?sz=128&domain_url=${url2.hostname}`,
+				`https://www.google.com/s2/favicons?sz=128&domain_url=${hostname}`,
 			);
 			if (!response2.ok) {
 				return null;


### PR DESCRIPTION
in favIconLogic function for x.com we don't add `https://${getBaseUrl(url)}${favIcon} instead we return the favicon url give by the scrapper