### PR TITLE
feat(container-zoom): ✨ now only while clicking on image zoom will work

### DIFF
--- a/src/components/lightbox/LightBox.tsx
+++ b/src/components/lightbox/LightBox.tsx
@@ -116,13 +116,13 @@ export const CustomLightBox = ({
 					? IMAGE_TYPE_PREFIX
 					: undefined,
 
-				// Only include dimensions if not a PDF
+				// Only include dimensions if not a PDF or not a YouTube video
 				...(bookmark?.meta_data?.mediaType !== PDF_MIME_TYPE &&
 					!bookmark?.type?.includes(PDF_TYPE) &&
 					!bookmark?.url?.includes(YOUTUBE_COM) &&
 					!bookmark?.url?.includes(YOUTU_BE) && {
 						width: bookmark?.meta_data?.width ?? 1_200,
-						height: bookmark?.meta_data?.height ?? 800,
+						height: bookmark?.meta_data?.height ?? 1_200,
 					}),
 				// Add video-specific properties
 				...(isVideo && {
@@ -404,7 +404,7 @@ export const CustomLightBox = ({
 					LIGHTBOX_CLOSE_BUTTON,
 				],
 			}}
-			zoom={{ ref: zoomRef, doubleClickDelay: 100, maxZoomPixelRatio: 5 }}
+			zoom={{ ref: zoomRef, doubleClickDelay: 100, maxZoomPixelRatio: 100 }}
 		/>
 	);
 };

--- a/src/components/lightbox/LightBox.tsx
+++ b/src/components/lightbox/LightBox.tsx
@@ -264,6 +264,13 @@ export const CustomLightBox = ({
 						if (url.pathname.startsWith(`/embed/`)) {
 							return true;
 						}
+
+						if (
+							url.pathname.startsWith("/shorts/") &&
+							url.pathname.split("/")[2]
+						) {
+							return true;
+						}
 					}
 
 					return false;

--- a/src/components/lightbox/LightBox.tsx
+++ b/src/components/lightbox/LightBox.tsx
@@ -242,6 +242,36 @@ export const CustomLightBox = ({
 			);
 
 			let content = null;
+			const isYouTubeVideo = (
+				urlString: string | null | undefined,
+			): boolean => {
+				if (!urlString) return false;
+
+				try {
+					const url = new URL(urlString);
+					const host = url.hostname;
+
+					// Match video URLs only
+					if (host === YOUTU_BE) {
+						return Boolean(url.pathname.slice(1));
+					}
+
+					if (host === `www.${YOUTUBE_COM}` || host === YOUTUBE_COM) {
+						if (url.pathname === "/watch" && url.searchParams.has("v")) {
+							return true;
+						}
+
+						if (url.pathname.startsWith(`/embed/`)) {
+							return true;
+						}
+					}
+
+					return false;
+				} catch {
+					return false;
+				}
+			};
+
 			if (
 				bookmark?.meta_data?.mediaType?.startsWith(IMAGE_TYPE_PREFIX) ||
 				bookmark?.meta_data?.isOgImagePreferred ||
@@ -258,10 +288,7 @@ export const CustomLightBox = ({
 				bookmark?.type?.includes(PDF_TYPE)
 			) {
 				content = renderPDFSlide();
-			} else if (
-				bookmark?.url?.includes(YOUTUBE_COM) ||
-				bookmark?.url?.includes(YOUTU_BE)
-			) {
+			} else if (isYouTubeVideo(bookmark?.url)) {
 				content = renderYouTubeSlide();
 			} else if (bookmark?.url) {
 				content = renderWebEmbedSlide();

--- a/src/components/lightbox/objectFallBack.tsx
+++ b/src/components/lightbox/objectFallBack.tsx
@@ -130,14 +130,50 @@ export const EmbedWithFallback = ({
 							draggable={false}
 							height={placeholderHeight}
 							onDoubleClick={(event) => {
+								const img = event.currentTarget;
+
+								// Get dimensions of rendered image inside the box
+								const containerWidth = img.clientWidth;
+								const containerHeight = img.clientHeight;
+								const imageAspectRatio = img.naturalWidth / img.naturalHeight;
+								const containerAspectRatio = containerWidth / containerHeight;
+
+								let renderedHeight;
+								let renderedWidth;
+								if (imageAspectRatio > containerAspectRatio) {
+									// image is wider, height is constrained
+									renderedWidth = containerWidth;
+									renderedHeight = containerWidth / imageAspectRatio;
+								} else {
+									// image is taller, width is constrained
+									renderedHeight = containerHeight;
+									renderedWidth = containerHeight * imageAspectRatio;
+								}
+
+								// Calculate bounds of the actual visible image
+								const offsetX = (containerWidth - renderedWidth) / 2;
+								const offsetY = (containerHeight - renderedHeight) / 2;
+
+								const clickX = event.nativeEvent.offsetX;
+								const clickY = event.nativeEvent.offsetY;
+
+								const insideVisibleImage =
+									clickX >= offsetX &&
+									clickX <= offsetX + renderedWidth &&
+									clickY >= offsetY &&
+									clickY <= offsetY + renderedHeight;
+
+								if (!insideVisibleImage) return;
+
+								// Proceed with zoom if clicked inside the visible part
 								event.stopPropagation();
 								const zoom = getZoomRef();
 								if (!zoom) return;
 
-								if (zoom?.zoom > 1) {
-									zoom?.zoomOut();
+								if (zoom.zoom > 1) {
+									zoom.zoomOut();
 								} else {
-									zoom?.zoomIn();
+									zoom.zoomIn();
 								}
 							}}
 							src={placeholder}


### PR DESCRIPTION
- zoom only works when interacting with the image directly, before we could interact outisde the container for images bigger than 1200 px

 

https://github.com/user-attachments/assets/9cca8f2f-e394-4832-ac31-a5ceea5d9dcd

- youtube videos are handled better - only videos and shorts will give a player others will just show ogImage or screenshot


-very long images are handled properly in lightbox 

https://github.com/user-attachments/assets/581475db-aa11-485c-833a-ae9302c45aa6

