### PR TITLE
fix: add https: in x.com favicon

### DIFF
--- a/src/pages/api/bookmark/add-remaining-bookmark-data.ts
+++ b/src/pages/api/bookmark/add-remaining-bookmark-data.ts
@@ -184,7 +184,7 @@ export default async function handler(
 				return favIcon;
 			} else {
 				return hostname === "x.com"
-					? favIcon
+					? "https:" + favIcon
 					: `https://${getBaseUrl(url)}${favIcon}`;
 			}
 		} else {


### PR DESCRIPTION
x.com favicon from the scrapper://abs.twimg.com/favicons/twitter.3.ico
so adding 'https:' will get us the x.com favIcon