### PR TITLE
fix(search): search by tag

### DIFF
--- a/src/pages/api/bookmark/search-bookmarks.ts
+++ b/src/pages/api/bookmark/search-bookmarks.ts
@@ -21,6 +21,7 @@ import {
 	imageFileTypes,
 	IMAGES_URL,
 	LINKS_URL,
+	PAGINATION_LIMIT,
 	TRASH_URL,
 	TWEETS_URL,
 	tweetType,
@@ -55,7 +56,7 @@ export default async function handler(
 	const search = request.query.search as string;
 
 	const offset = Number.parseInt(request.query.offset as string, 10) || 0;
-	const limit = Number.parseInt(request.query.limit as string, 10) || 25;
+	const limit = PAGINATION_LIMIT;
 
 	const searchText = search?.replace(GET_TEXT_WITH_AT_CHAR, "");
 

--- a/src/pages/api/bookmark/search-bookmarks.ts
+++ b/src/pages/api/bookmark/search-bookmarks.ts
@@ -54,6 +54,9 @@ export default async function handler(
 	const { category_id, is_shared_category } = request.query;
 	const search = request.query.search as string;
 
+	const offset = Number.parseInt(request.query.offset as string, 10) || 0;
+	const limit = Number.parseInt(request.query.limit as string, 10) || 25;
+
 	const searchText = search?.replace(GET_TEXT_WITH_AT_CHAR, "");
 
 	const matchedSearchTag = search?.match(GET_TEXT_WITH_AT_CHAR);
@@ -69,7 +72,8 @@ export default async function handler(
 		.rpc("search_bookmarks_debugging", {
 			search_text: searchText,
 		})
-		.eq("trash", category_id === TRASH_URL);
+		.eq("trash", category_id === TRASH_URL)
+		.range(offset, offset + limit);
 
 	// TODO: is_shared_category needs to be got in api itself not in payload
 	if (is_shared_category === "false") {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,7 +27,7 @@ export const URL_PATTERN =
 	// eslint-disable-next-line  unicorn/no-unsafe-regex
 	/^(https?:\/\/)?(www\.)?[\da-z-]+(\.[\da-z-]+)*\.[a-z]{2,}(?::\d{1,5})?(\/\S*)?$/iu;
 export const GET_NAME_FROM_EMAIL_PATTERN = /^([^@]*)@/u;
-export const GET_TEXT_WITH_AT_CHAR = /[A-Za-z]*@[A-Za-z]*/gu;
+export const GET_TEXT_WITH_AT_CHAR = /[A-Za-z\d]*@[A-Za-z\d]*/gu;
 export const EMAIL_CHECK_PATTERN =
 	// eslint-disable-next-line unicorn/no-unsafe-regex, unicorn/better-regex, require-unicode-regexp, regexp/strict, regexp/no-useless-escape, no-useless-escape
 	/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;


### PR DESCRIPTION
search using tag: when we have a number in the tag name or the tag name is alpha numeric then the search is not happening as expected which is due to regex check, now it is fixed

pagination: pagination is done for the test search
